### PR TITLE
Optimize plugin loading

### DIFF
--- a/includes/class-assets.php
+++ b/includes/class-assets.php
@@ -8,14 +8,14 @@ namespace App;
 class Assets {
 
 
-	function __construct() {
+        function __construct() {
 
-		if ( is_admin() ) {
-			add_action( 'admin_enqueue_scripts', array( $this, 'register' ), 5 );
-		} else {
-			add_action( 'wp_enqueue_scripts', array( $this, 'register' ), 5 );
-		}
-	}
+                if ( is_admin() ) {
+                        add_action( 'admin_enqueue_scripts', array( $this, 'register' ), 5 );
+                } elseif ( function_exists( 'melhor_envio_should_load_plugin' ) && melhor_envio_should_load_plugin() ) {
+                        add_action( 'wp_enqueue_scripts', array( $this, 'register' ), 5 );
+                }
+        }
 
 	/**
 	 * Register our app scripts and styles

--- a/readme.md
+++ b/readme.md
@@ -12,6 +12,8 @@ License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
 Plugin para cotação e compra de fretes utilizando a API da Melhor Envio.
 
+Nota: os recursos do plugin são carregados apenas nas páginas de conta, carrinho e checkout do WooCommerce ou no painel administrativo.
+
 == Description ==
 Com o Melhor Envio é possível fazer gratuitamente cotações simultâneas com os Correios e diversas transportadoras privadas de forma ágil e eficiente. A plataforma possui contratos com várias empresas de logística para oferecer fretes em condições mais competitivas aos vendedores online.
 A tecnologia já ajudou mais de 50 mil lojistas a otimizar a gestão de fretes acessando uma série de vantagens exclusivas sem precisar negociar individualmente com as transportadoras.


### PR DESCRIPTION
## Summary
- avoid loading the plugin on unrelated pages
- load assets only when needed
- register shipping methods conditionally
- document when plugin loads

## Testing
- `npm run build` *(fails: cross-env not found)*

------
https://chatgpt.com/codex/tasks/task_e_68791af7d4988331904c87479a1bb240